### PR TITLE
fix: preserve theme across view transitions

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -114,6 +114,11 @@ const imageAlt =
         syncThemeToggle()
       })
 
+      document.addEventListener("astro:before-swap", (event) => {
+        const theme = document.documentElement.dataset.theme
+        if (theme) event.newDocument.documentElement.dataset.theme = theme
+      })
+
       document.addEventListener("astro:after-swap", () => {
         if (!categoryNavigationPending) return
 


### PR DESCRIPTION
## Problem

The `<html>` element is server-rendered with a hardcoded `data-theme="dark"`. The inline head script restores the saved theme from `localStorage`, but it only runs on a full page load.

During a `ClientRouter` navigation, Astro copies the incoming document's root attributes onto the current `<html>`, which always says `dark`, and the inline head script is not re-executed. Toggling to light and then clicking any internal link (category, tool, footer) silently reverted the page to dark.

## Fix

Carry the current theme onto the incoming document in an `astro:before-swap`
listener, so the correct theme is in place before the swap happens.

Before: 

https://github.com/user-attachments/assets/63d6d3e9-93c6-4721-9732-d976abe28092

After:

https://github.com/user-attachments/assets/a7c38198-b818-48cb-8c23-927588d6c027