### PR TITLE
feat: add Madoo AI resource

### DIFF
--- a/src/data/free-tiers.ts
+++ b/src/data/free-tiers.ts
@@ -79,6 +79,7 @@ export const freeTiers: Record<string, LocalizedFreeTier> = {
   "Formspree": { en: "Free: 50 form submissions/month, unlimited forms and projects, spam filtering and email notifications.", es: "Gratis: 50 envíos de formulario/mes, formularios y proyectos ilimitados, antispam y avisos por email." },
   "Tally": { en: "Free: unlimited forms and submissions with most input types, payments, logic and integrations included.", es: "Gratis: formularios y respuestas ilimitados con casi todos los campos, pagos, lógica e integraciones." },
   "Web3Forms": { en: "Free: 250 form submissions/month, unlimited forms and websites, with no backend or account required.", es: "Gratis: 250 envíos de formulario/mes, formularios y webs ilimitados, sin backend ni cuenta." },
+  "Madoo AI": { en: "Free: 30 AI credits/month (5/day), 10 stored templates and test emails, no credit card; a 7-day trial of the paid plans is opt-in at sign-up.", es: "Gratis: 30 créditos de IA al mes (5/día), 10 plantillas guardadas y emails de prueba, sin tarjeta; incluye una prueba de 7 días de los planes de pago al registrarte." },
 
   "Sentry": { en: "Developer: 5k errors, 5M spans, 50 replays and 5 GB logs/month for one user.", es: "Developer: 5.000 errores, 5 M de spans, 50 replays y 5 GB de logs/mes para un usuario." },
   "Better Stack": { en: "Free: 10 monitors, 3-minute checks, 1 status page, 1 GB logs/month and 3-day retention.", es: "Gratis: 10 monitores, checks cada 3 min, 1 página de estado, 1 GB de logs/mes y 3 días de retención." },

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -89,6 +89,7 @@ const pricingUrls: Record<string, string> = {
   "Formspree": "https://formspree.io/plans",
   "Tally": "https://tally.so/pricing",
   "Web3Forms": "https://web3forms.com/pricing",
+  "Madoo AI": "https://madooai.com/pricing",
   "Sentry": "https://sentry.io/pricing/",
   "Better Stack": "https://betterstack.com/pricing",
   "Grafana Cloud": "https://grafana.com/pricing/",
@@ -211,6 +212,7 @@ const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "acce
   { name: "Formspree", url: "https://formspree.io", category: "email", tags: ["forms", "static", "email"], description: { en: "Add a reliable form backend to any site without writing server code.", es: "Añade un backend fiable para formularios sin escribir código de servidor." } },
   { name: "Tally", url: "https://tally.so", category: "email", tags: ["forms", "no-code", "surveys"], description: { en: "Create flexible forms and surveys with a generous free plan.", es: "Crea formularios y encuestas flexibles con un plan gratuito generoso." } },
   { name: "Web3Forms", url: "https://web3forms.com", category: "email", tags: ["forms", "api", "static"], description: { en: "Receive static-site form submissions directly in your inbox through an API.", es: "Recibe formularios de sitios estáticos en tu email mediante una API." } },
+  { name: "Madoo AI", url: "https://madooai.com", faviconFile: "https://madooai.com/favicon.ico", category: "email", tags: ["email", "ai", "templates"], description: { en: "Generate complete, on-brand email templates with AI and export them to Mailchimp, Klaviyo, HubSpot and other platforms; the free plan includes 30 AI credits per month.", es: "Genera plantillas de email completas y con tu marca usando IA y expórtalas a Mailchimp, Klaviyo, HubSpot y otras plataformas; el plan gratis incluye 30 créditos de IA al mes." } },
 
   // Observability
   { name: "Sentry", url: "https://sentry.io", category: "observability", featured: true, tags: ["errors", "tracing", "replay"], description: { en: "Track errors, performance traces and user sessions across your stack.", es: "Monitoriza errores, trazas de rendimiento y sesiones en todo tu stack." } },


### PR DESCRIPTION
## What changed and why

Adds **Madoo AI** ([madooai.com](https://madooai.com)) to the **Email & forms** category. Madoo AI generates complete, on-brand email templates with AI and exports them to Mailchimp, Klaviyo, HubSpot and other marketing platforms.

- `src/data/resources.ts`: catalog entry + pricing URL in the `pricingUrls` map.
- `src/data/free-tiers.ts`: free-tier summary in English and Spanish.
- `accessRequirement` defaults to `no-card` (no credit card required for the free plan).

## Free tier

- 30 AI credits/month (5/day), 10 stored templates and test emails — no credit card.
- Opt-in 7-day trial of the paid plans at sign-up.

## Source verified

Pricing and free-tier limits verified against the official pricing page: https://madooai.com/pricing

## Checks run

- `pnpm check` — 0 errors, 0 warnings, 0 hints
- `pnpm build` — 258 pages built successfully (includes `/tools/madoo-ai`)

## Visual / accessibility impact

None beyond a new catalog card; favicon served from the product's own `favicon.ico`.