### PR TITLE
Feat/add prisma postgres

### DIFF
--- a/src/data/free-tiers.ts
+++ b/src/data/free-tiers.ts
@@ -46,6 +46,7 @@ export const freeTiers: Record<string, LocalizedFreeTier> = {
   "Upstash": { en: "Redis Free: 256 MB and 500k commands/month; QStash includes 1,000 messages/day.", es: "Redis Free: 256 MB y 500.000 comandos/mes; QStash incluye 1.000 mensajes/día." },
   "CockroachDB": { en: "Basic: up to 10 GiB storage and 50M request units/month at no cost, across one organization.", es: "Basic: hasta 10 GiB y 50 M de request units/mes sin coste dentro de una organización." },
   "Aiven": { en: "Free plans for PostgreSQL, MySQL, Valkey and Kafka: one small node with limited storage and no SLA.", es: "Planes gratis para PostgreSQL, MySQL, Valkey y Kafka: un nodo pequeño, storage limitado y sin SLA." },
+    "Prisma Postgres": { en: "Free: 100k operations, 500 MB storage and 50 databases; quotas are shared across all databases in the account.", es: "Gratis: 100.000 operaciones, 500 MB de almacenamiento y 50 bases de datos; las cuotas se comparten entre todas las bases de la cuenta." },
 
   "Braintrust": { en: "Free: 1 GB of logs/month, 10k scores and experiments, prompt playground and unlimited users.", es: "Gratis: 1 GB de logs/mes, 10.000 scores y experimentos, playground de prompts y usuarios ilimitados." },
   "Langfuse": { en: "Hobby: 50k usage units/month with 30-day retention; self-hosting the open-source edition is also free.", es: "Hobby: 50.000 unidades de uso/mes y 30 días de retención; la edición open source self-hosted también es gratis." },

--- a/src/data/free-tiers.ts
+++ b/src/data/free-tiers.ts
@@ -46,7 +46,7 @@ export const freeTiers: Record<string, LocalizedFreeTier> = {
   "Upstash": { en: "Redis Free: 256 MB and 500k commands/month; QStash includes 1,000 messages/day.", es: "Redis Free: 256 MB y 500.000 comandos/mes; QStash incluye 1.000 mensajes/día." },
   "CockroachDB": { en: "Basic: up to 10 GiB storage and 50M request units/month at no cost, across one organization.", es: "Basic: hasta 10 GiB y 50 M de request units/mes sin coste dentro de una organización." },
   "Aiven": { en: "Free plans for PostgreSQL, MySQL, Valkey and Kafka: one small node with limited storage and no SLA.", es: "Planes gratis para PostgreSQL, MySQL, Valkey y Kafka: un nodo pequeño, storage limitado y sin SLA." },
-    "Prisma Postgres": { en: "Free: 100k operations, 500 MB storage and 50 databases; quotas are shared across all databases in the account.", es: "Gratis: 100.000 operaciones, 500 MB de almacenamiento y 50 bases de datos; las cuotas se comparten entre todas las bases de la cuenta." },
+  "Prisma Postgres": { en: "Free: 100k operations, 500 MB storage and 50 databases; quotas are shared across all databases in the account.", es: "Gratis: 100.000 operaciones, 500 MB de almacenamiento y 50 bases de datos; las cuotas se comparten entre todas las bases de la cuenta." },
 
   "Braintrust": { en: "Free: 1 GB of logs/month, 10k scores and experiments, prompt playground and unlimited users.", es: "Gratis: 1 GB de logs/mes, 10.000 scores y experimentos, playground de prompts y usuarios ilimitados." },
   "Langfuse": { en: "Hobby: 50k usage units/month with 30-day retention; self-hosting the open-source edition is also free.", es: "Hobby: 50.000 unidades de uso/mes y 30 días de retención; la edición open source self-hosted también es gratis." },

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -22,7 +22,7 @@ export interface Resource {
   featured?: boolean
 }
 
-export const sourceReviewedAt = "2026-07-23"
+export const sourceReviewedAt = "2026-07-24"
 
 export const categories: Category[] = [
   { id: "hosting", icon: "cloud-computing", name: { en: "Hosting & deploy", es: "Hosting y deploy" } },
@@ -152,6 +152,7 @@ const pricingUrls: Record<string, string> = {
   "Cloudinary": "https://cloudinary.com/pricing",
   "Uploadcare": "https://uploadcare.com/pricing/",
   "ImageKit": "https://imagekit.io/plans",
+  "Prisma Postgres": "https://www.prisma.io/pricing",
 }
 
 const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "accessRequirement">[] = [
@@ -175,6 +176,7 @@ const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "acce
   { name: "Upstash", url: "https://upstash.com", category: "data", featured: true, tags: ["redis", "kafka", "serverless"], description: { en: "Serverless Redis, Kafka and workflow tools with usage-based free tiers.", es: "Redis, Kafka y workflows serverless con capas gratuitas por uso." } },
   { name: "CockroachDB", url: "https://www.cockroachlabs.com", faviconFile: "cockroachlabs.com.webp", category: "data", tags: ["sql", "distributed", "cloud"], description: { en: "Distributed SQL built for resilient, globally available applications.", es: "SQL distribuido para aplicaciones resistentes y disponibles globalmente." } },
   { name: "Aiven", url: "https://aiven.io", category: "data", tags: ["postgres", "valkey", "kafka"], description: { en: "Managed open-source data services with free plans for selected products.", es: "Servicios de datos open source gestionados con planes gratuitos seleccionados." } },
+  { name: "Prisma Postgres", url: "https://www.prisma.io/postgres", category: "data", tags: ["postgres", "serverless", "database"], description: { en: "Managed serverless Postgres with instant provisioning, connection pooling and support for standard PostgreSQL clients.", es: "Postgres serverless gestionado con aprovisionamiento instantáneo, pooling de conexiones y soporte para clientes PostgreSQL estándar." } },
 
   // AI
   { name: "Braintrust", url: "https://www.braintrustdata.com", category: "ai", tags: ["evals", "prompts", "data"], description: { en: "Evaluate AI applications, compare prompts and manage test datasets.", es: "Evalúa aplicaciones de IA, compara prompts y gestiona datasets de prueba." } },

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -59,6 +59,7 @@ const pricingUrls: Record<string, string> = {
   "Upstash": "https://upstash.com/pricing",
   "CockroachDB": "https://www.cockroachlabs.com/pricing/",
   "Aiven": "https://aiven.io/pricing",
+  "Prisma Postgres": "https://www.prisma.io/pricing",
   "Braintrust": "https://www.braintrust.dev/pricing",
   "Langfuse": "https://langfuse.com/pricing",
   "Hugging Face": "https://huggingface.co/pricing",
@@ -152,7 +153,6 @@ const pricingUrls: Record<string, string> = {
   "Cloudinary": "https://cloudinary.com/pricing",
   "Uploadcare": "https://uploadcare.com/pricing/",
   "ImageKit": "https://imagekit.io/plans",
-  "Prisma Postgres": "https://www.prisma.io/pricing",
 }
 
 const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "accessRequirement">[] = [


### PR DESCRIPTION
## What changed

Added Prisma Postgres to the Data & backend category.

The new entry includes:

* An English and Spanish description.
* The official Prisma Postgres product page.
* The official pricing page.
* The verified permanent free-tier limits.
* The correct no-credit-card access requirement.

## Free-tier details

The Prisma Postgres Free plan currently includes:

* 100,000 database operations.
* 500 MB of storage.
* Up to 50 databases.
* No credit card required.

Usage quotas are shared across all databases in the account.

## Official sources

* Product: https://www.prisma.io/postgres
* Pricing and limits: https://www.prisma.io/pricing

## Visual and accessibility impact

No interface or accessibility changes. This pull request only adds a new catalog entry.

## Checks

* [x] `pnpm check`
* [x] `pnpm build`
