### PR TITLE
feat: add Mydentify AI Crawler Access Checker

### DIFF
--- a/public/favicons/mydentify.com.svg
+++ b/public/favicons/mydentify.com.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Mydentify">
+  <rect width="64" height="64" rx="14" fill="#111111"/>
+  <circle cx="29" cy="29" r="13" fill="none" stroke="#fafafa" stroke-width="5"/>
+  <path d="M39 39l11 11" stroke="#fafafa" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="29" cy="29" r="4" fill="#22d3ee"/>
+</svg>

--- a/src/data/free-tiers.ts
+++ b/src/data/free-tiers.ts
@@ -20,6 +20,7 @@ export const accessRequirements: Partial<Record<string, AccessRequirement>> = {
   "tldraw": "no-signup",
   "Fontshare": "no-signup",
   "Mozilla Observatory": "no-signup",
+  "Mydentify AI Crawler Access Checker": "no-signup",
   "Have I Been Pwned": "no-signup",
 }
 
@@ -63,6 +64,7 @@ export const freeTiers: Record<string, LocalizedFreeTier> = {
   "Pollinations.AI": { en: "Free image and text generation API with no sign-up or API key; public usage is rate-limited under fair use.", es: "API gratis de imagen y texto sin registro ni API key; el uso público tiene límites de fair use." },
   "Portkey": { en: "Free developer plan: AI gateway, caching, fallbacks and a limited monthly log allowance; inference is separate.", es: "Plan developer gratis: gateway, caché, fallbacks y una cuota mensual de logs; la inferencia se paga aparte." },
   "Comet Opik": { en: "Free cloud tier for one developer with limited monthly traces; the open-source self-hosted edition is unlimited.", es: "Cloud gratis para un developer con trazas mensuales limitadas; la edición open source self-hosted es ilimitada." },
+  "Mydentify AI Crawler Access Checker": { en: "Completely free public checker for six crawler names, robots.txt, page directives and response headers; no sign-up or card required.", es: "Comprobador público y gratis para seis crawlers, robots.txt, directivas de página y headers de respuesta; sin registro ni tarjeta." },
 
   "Clerk": { en: "Hobby: 50k monthly retained users per app, up to 5 dashboard seats and 100 organizations.", es: "Hobby: 50.000 usuarios retenidos al mes por app, hasta 5 miembros y 100 organizaciones." },
   "Auth0": { en: "Free: up to 25k monthly active users, social connections, passwordless login and 5 organizations.", es: "Gratis: hasta 25.000 usuarios activos/mes, conexiones sociales, passwordless y 5 organizaciones." },

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -22,7 +22,7 @@ export interface Resource {
   featured?: boolean
 }
 
-export const sourceReviewedAt = "2026-07-23"
+export const sourceReviewedAt = "2026-08-12"
 
 export const categories: Category[] = [
   { id: "hosting", icon: "cloud-computing", name: { en: "Hosting & deploy", es: "Hosting y deploy" } },
@@ -75,6 +75,7 @@ const pricingUrls: Record<string, string> = {
   "Pollinations.AI": "https://pollinations.ai/docs",
   "Portkey": "https://portkey.ai/pricing",
   "Comet Opik": "https://www.comet.com/site/pricing/",
+  "Mydentify AI Crawler Access Checker": "https://mydentify.com/tools/ai-crawler-access-checker",
   "Clerk": "https://clerk.com/pricing",
   "Auth0": "https://auth0.com/pricing",
   "WorkOS": "https://workos.com/pricing",
@@ -193,6 +194,7 @@ const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "acce
   { name: "Pollinations.AI", url: "https://pollinations.ai", category: "ai", tags: ["images", "api", "open source"], description: { en: "Generate AI images through a free API without sign-up or API keys.", es: "Genera imágenes con IA mediante una API gratis sin registro ni claves." } },
   { name: "Portkey", url: "https://portkey.ai", category: "ai", tags: ["gateway", "observability", "llm"], description: { en: "An AI gateway and control plane with logging, routing and guardrails.", es: "Gateway y panel de control de IA con logs, routing y guardrails." } },
   { name: "Comet Opik", url: "https://www.comet.com/site/products/opik", category: "ai", tags: ["evals", "tracing", "open source"], description: { en: "Trace, evaluate and test LLM applications throughout development.", es: "Traza, evalúa y prueba aplicaciones con LLM durante su desarrollo." } },
+  { name: "Mydentify AI Crawler Access Checker", url: "https://mydentify.com/tools/ai-crawler-access-checker", faviconFile: "mydentify.com.svg", category: "ai", tags: ["crawlers", "robots.txt", "seo"], description: { en: "Check whether documented OpenAI and Anthropic crawlers can access a public page.", es: "Comprueba si los crawlers documentados de OpenAI y Anthropic pueden acceder a una página pública." } },
 
   // Auth
   { name: "Clerk", url: "https://clerk.com", category: "auth", featured: true, tags: ["auth", "components", "organizations"], description: { en: "Authentication and user management with polished prebuilt components.", es: "Autenticación y gestión de usuarios con componentes listos y cuidados." } },


### PR DESCRIPTION
## What changed

- Adds `Mydentify AI Crawler Access Checker` to AI & machine learning.
- Adds equivalent English and Spanish descriptions and free-tier summaries.
- Marks the tool as no-signup and includes its official favicon.
- Updates `sourceReviewedAt` to the date of this verification.

## Free-tier evidence

Official tool and limits page: https://mydentify.com/tools/ai-crawler-access-checker

The public tool is free and requires no account or card. It checks six documented OpenAI and Anthropic crawler names, robots.txt rules, page directives, and response headers. The page also states the important limitation that requests come from Mydentify infrastructure rather than verified provider IP ranges.

Public MIT source: https://github.com/mitdralla/mydentify-ai-crawler-access-checker

## Verification

- `pnpm check` — 0 errors, warnings, or hints
- `pnpm build` — 258 static pages generated
- Verified the generated English and Spanish detail routes, canonical metadata, sitemap entries, direct tool URL, and exact `Mydentify` spelling

## Visual and accessibility impact

The change uses the existing resource-page structure and adds the official SVG icon with an accessible label. No shared component or interaction behavior changes.

Disclosure: I maintain Mydentify and the submitted tool.