### PR TITLE
Add CSR.plus to security resources

### DIFF
--- a/src/data/free-tiers.ts
+++ b/src/data/free-tiers.ts
@@ -21,6 +21,7 @@ export const accessRequirements: Partial<Record<string, AccessRequirement>> = {
   "Fontshare": "no-signup",
   "Mozilla Observatory": "no-signup",
   "Have I Been Pwned": "no-signup",
+  "CSR.plus": "no-signup",
 }
 
 /**
@@ -132,6 +133,7 @@ export const freeTiers: Record<string, LocalizedFreeTier> = {
   "Socket": { en: "Free for open-source projects; personal GitHub protection and dependency analysis are available at no cost.", es: "Gratis para open source; la protección personal de GitHub y el análisis de dependencias no tienen coste." },
   "Mozilla Observatory": { en: "Completely free public web-security scanner with unlimited on-demand scans and no account required.", es: "Escáner público de seguridad web totalmente gratis, con análisis bajo demanda y sin necesidad de cuenta." },
   "Have I Been Pwned": { en: "Pwned Passwords and basic breach lookups are free; authenticated account and domain API access is paid.", es: "Pwned Passwords y las búsquedas básicas son gratis; la API autenticada de cuentas y dominios es de pago." },
+  "CSR.plus": { en: "Free and unlimited CSR generation with RSA, ECDSA and Ed25519 keys, plus a free no-sign-up API.", es: "Generación gratuita e ilimitada de CSR con claves RSA, ECDSA y Ed25519, además de una API gratuita sin registro." },
 
   "Linear": { en: "Free: unlimited members, 2 teams and 250 issues, with Slack/GitHub integrations and API access.", es: "Gratis: miembros ilimitados, 2 equipos y 250 issues, con integraciones de Slack/GitHub y API." },
   "Notion": { en: "Free for individuals with unlimited pages; teams get a limited collaborative block trial and 5 MB uploads.", es: "Gratis para uso individual con páginas ilimitadas; los equipos tienen bloques limitados y subidas de 5 MB." },

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -22,7 +22,7 @@ export interface Resource {
   featured?: boolean
 }
 
-export const sourceReviewedAt = "2026-07-23"
+export const sourceReviewedAt = "2026-08-16"
 
 export const categories: Category[] = [
   { id: "hosting", icon: "cloud-computing", name: { en: "Hosting & deploy", es: "Hosting y deploy" } },
@@ -136,6 +136,7 @@ const pricingUrls: Record<string, string> = {
   "Socket": "https://socket.dev/pricing",
   "Mozilla Observatory": "https://observatory.mozilla.org/",
   "Have I Been Pwned": "https://haveibeenpwned.com/API/Key",
+  "CSR.plus": "https://csr.plus/docs/api",
   "Linear": "https://linear.app/pricing",
   "Notion": "https://www.notion.so/pricing",
   "Trello": "https://trello.com/pricing",
@@ -270,6 +271,7 @@ const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "acce
   { name: "Socket", url: "https://socket.dev", category: "security", tags: ["supply chain", "npm", "dependencies"], description: { en: "Protect JavaScript supply chains by analyzing dependency behavior.", es: "Protege la cadena de suministro JavaScript analizando dependencias." } },
   { name: "Mozilla Observatory", url: "https://observatory.mozilla.org", category: "security", tags: ["headers", "audit", "web"], description: { en: "Scan a website for security headers and common web hardening practices.", es: "Escanea headers y prácticas habituales de protección web." } },
   { name: "Have I Been Pwned", url: "https://haveibeenpwned.com/API/v3", category: "security", tags: ["breaches", "api", "passwords"], description: { en: "Check accounts and domains against known data breaches through an API.", es: "Comprueba cuentas y dominios frente a filtraciones conocidas mediante API." } },
+  { name: "CSR.plus", url: "https://csr.plus", category: "security", tags: ["ssl", "csr", "certificates", "api"], description: { en: "Generate certificate signing requests and private keys entirely in the browser, no OpenSSL required.", es: "Genera solicitudes de firma de certificados y claves privadas en el navegador, sin necesidad de OpenSSL." } },
 
   // Collaboration
   { name: "Linear", url: "https://linear.app", category: "collaboration", featured: true, tags: ["issues", "roadmap", "product"], description: { en: "Fast issue tracking, cycles and product roadmaps for software teams.", es: "Issues, ciclos y roadmaps rápidos para equipos de software." } },


### PR DESCRIPTION
Adds CSR.plus to the security category: a free, browser-based CSR and private key generator with a no-sign-up API (RSA, ECDSA, Ed25519). No account required, unlimited free tier.

- Resources entry added in both English and Spanish
- Free tier summary added in both languages
- Access requirement: no sign-up
- `pnpm check` and `pnpm build` both pass