### PR TITLE
Add MonitorFlare to observability

### DIFF
--- a/src/data/free-tiers.ts
+++ b/src/data/free-tiers.ts
@@ -21,6 +21,7 @@ export const accessRequirements: Partial<Record<string, AccessRequirement>> = {
   "Fontshare": "no-signup",
   "Mozilla Observatory": "no-signup",
   "Have I Been Pwned": "no-signup",
+  "MonitorFlare": "no-signup",
 }
 
 /**
@@ -87,6 +88,7 @@ export const freeTiers: Record<string, LocalizedFreeTier> = {
   "Uptime.com": { en: "No permanent free tier: the platform currently offers a time-limited free trial of its paid monitoring plans.", es: "Sin capa gratis permanente: actualmente ofrece una prueba temporal de sus planes de monitorización de pago." },
   "Checkly": { en: "Free: 10k API checks and 1,500 browser checks/month, 1-minute frequency and 7-day retention.", es: "Gratis: 10.000 checks de API y 1.500 de navegador/mes, frecuencia de 1 min y 7 días de retención." },
   "healthchecks.io": { en: "Hosted free plan: 20 checks for one team member with email, webhook and chat integrations.", es: "Plan alojado gratis: 20 checks para un miembro con integraciones de email, webhooks y chat." },
+  "MonitorFlare": { en: "Free and unlimited self-hosted monitoring on Cloudflare's free tier with 9 notification channels.", es: "Monitorización auto-alojada gratuita e ilimitada en el plan gratis de Cloudflare con 9 canales de notificación." },
   "New Relic": { en: "Free: 100 GB data ingest/month, one full-platform user and unlimited basic users.", es: "Gratis: 100 GB de ingesta/mes, un usuario full-platform y usuarios básicos ilimitados." },
   "Logtail": { en: "Better Stack free logs: 1 GB/month with 3-day retention, live tail, SQL queries and alerts.", es: "Logs gratis de Better Stack: 1 GB/mes y 3 días de retención, live tail, consultas SQL y alertas." },
 

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -22,7 +22,7 @@ export interface Resource {
   featured?: boolean
 }
 
-export const sourceReviewedAt = "2026-07-23"
+export const sourceReviewedAt = "2026-08-16"
 
 export const categories: Category[] = [
   { id: "hosting", icon: "cloud-computing", name: { en: "Hosting & deploy", es: "Hosting y deploy" } },
@@ -96,6 +96,7 @@ const pricingUrls: Record<string, string> = {
   "Uptime.com": "https://uptime.com/pricing",
   "Checkly": "https://www.checklyhq.com/pricing/",
   "healthchecks.io": "https://healthchecks.io/pricing/",
+  "MonitorFlare": "https://monitorflare.csr.plus/",
   "New Relic": "https://newrelic.com/pricing",
   "Logtail": "https://betterstack.com/pricing",
   "GitHub Actions": "https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions",
@@ -220,6 +221,7 @@ const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "acce
   { name: "Uptime.com", url: "https://uptime.com", faviconFile: "uptime.com.webp", category: "observability", tags: ["uptime", "synthetic", "alerts"], description: { en: "Website, API and real-user monitoring with alerts and incident workflows.", es: "Monitorización de webs, APIs y usuarios reales con alertas y gestión de incidentes." } },
   { name: "Checkly", url: "https://www.checklyhq.com", category: "observability", tags: ["playwright", "synthetic", "api"], description: { en: "Code-first synthetic monitoring for web apps and APIs using Playwright.", es: "Monitorización sintética como código para webs y APIs con Playwright." } },
   { name: "healthchecks.io", url: "https://healthchecks.io", category: "observability", tags: ["cron", "alerts", "jobs"], description: { en: "Monitor cron jobs and background tasks with simple heartbeat URLs.", es: "Monitoriza tareas cron y procesos en background con URLs heartbeat." } },
+  { name: "MonitorFlare", url: "https://monitorflare.csr.plus", category: "observability", tags: ["uptime", "status", "cloudflare"], description: { en: "Self-hosted uptime monitoring and status page on the Cloudflare free tier.", es: "Monitorización de uptime y página de estado auto-alojada en el plan gratis de Cloudflare." } },
   { name: "New Relic", url: "https://newrelic.com", category: "observability", tags: ["apm", "logs", "infra"], description: { en: "Full-stack application performance and infrastructure monitoring.", es: "Monitorización full-stack del rendimiento e infraestructura." } },
   { name: "Logtail", url: "https://betterstack.com/logs", category: "observability", tags: ["logs", "sql", "alerts"], description: { en: "Centralize structured logs and query them quickly with SQL-like syntax.", es: "Centraliza logs estructurados y consúltalos con una sintaxis tipo SQL." } },
 


### PR DESCRIPTION
Adds MonitorFlare to the observability category: a self-hosted uptime monitor and public status page that runs entirely on the Cloudflare free tier (Workers + D1 + Pages). No sign-up, one-click deploy, 9 notification channels, 9 languages, MIT licensed.\n\n- Resources entry in English and Spanish\n- Free tier summary in both languages\n- Access requirement: no sign-up\n- `pnpm check` and `pnpm build` both pass