### PR TITLE
feat: add AnyHook to APIs & automation

### DIFF
--- a/src/data/free-tiers.ts
+++ b/src/data/free-tiers.ts
@@ -110,6 +110,7 @@ export const freeTiers: Record<string, LocalizedFreeTier> = {
   "Microsoft Clarity": { en: "Completely free: unlimited projects, heatmaps and session recordings with no traffic cap.", es: "Totalmente gratis: proyectos, mapas de calor y grabaciones ilimitados, sin límite de tráfico." },
   "Axiom": { en: "Free: 500 GB-hours of query time and 25 GB ingest/month, with 30-day retention.", es: "Gratis: 500 GB-horas de consulta y 25 GB de ingesta/mes, con 30 días de retención." },
 
+  "AnyHook": { en: "Free: 3,000 events/month capped at 100/day, 1 app, 3 delivery attempts and 3 days of history, with no credit card.", es: "Gratis: 3.000 eventos/mes con tope de 100/día, 1 app, 3 intentos de entrega y 3 días de historial, sin tarjeta." },
   "Pipedream": { en: "Free: 100 workflow credits/month, 3 active workflows and unlimited testing in the builder.", es: "Gratis: 100 créditos de workflows/mes, 3 workflows activos y pruebas ilimitadas en el editor." },
   "Beeceptor": { en: "Free: 50 requests/day, 1 mock endpoint and 10 days of request history, with no credit card.", es: "Gratis: 50 peticiones/día, 1 endpoint mock y 10 días de historial, sin tarjeta." },
   "MockAPI": { en: "Free: one project with up to 2 resources and basic fake REST endpoints for prototyping.", es: "Gratis: un proyecto con hasta 2 recursos y endpoints REST falsos básicos para prototipos." },

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -116,6 +116,7 @@ const pricingUrls: Record<string, string> = {
   "Cloudflare Web Analytics": "https://developers.cloudflare.com/web-analytics/",
   "Microsoft Clarity": "https://clarity.microsoft.com/pricing",
   "Axiom": "https://axiom.co/pricing",
+  "AnyHook": "https://anyhook.net/pricing",
   "Pipedream": "https://pipedream.com/docs/pricing",
   "Beeceptor": "https://beeceptor.com/pricing",
   "MockAPI": "https://mockapi.io/pricing",
@@ -255,6 +256,7 @@ const resourceCatalog: Omit<Resource, "slug" | "pricingUrl" | "freeTier" | "acce
   { name: "Open-Meteo", url: "https://open-meteo.com", category: "api", tags: ["weather", "forecast", "open data"], description: { en: "Global weather forecasts and historical data through a free JSON API with no API key.", es: "Pronósticos globales e históricos del tiempo mediante una API JSON gratis sin API key." } },
   { name: "OpenGraph.to", url: "https://www.opengraph.to", faviconFile: "opengraph.to.svg", category: "api", tags: ["open graph", "seo", "social"], description: { en: "Scrape Open Graph, Twitter Card and SEO tags for any public URL: title, description, image, score, issues and suggested meta tags as JSON.", es: "Extrae tags Open Graph, Twitter Card y SEO de cualquier URL pública: título, descripción, imagen, puntuación, problemas y meta tags sugeridos en JSON." } },
   { name: "Hoppscotch", url: "https://hoppscotch.io", category: "api", tags: ["api client", "graphql", "realtime"], description: { en: "A fast web API client for REST, GraphQL and realtime protocols.", es: "Cliente web rápido para APIs REST, GraphQL y protocolos realtime." } },
+  { name: "AnyHook", url: "https://anyhook.net", category: "api", tags: ["webhooks", "retries", "logs"], description: { en: "Take delivery of inbound webhooks without running your own endpoint: retries, event log and replay.", es: "Recibe webhooks entrantes sin montar tu propio endpoint: reintentos, registro de eventos y reenvío." } },
 
   // Design
   { name: "Figma", url: "https://www.figma.com", category: "design", featured: true, tags: ["ui", "prototype", "collaboration"], description: { en: "Collaborative interface design, prototyping and developer handoff.", es: "Diseño de interfaces, prototipado y handoff colaborativo." } },


### PR DESCRIPTION
## What

Adds **AnyHook** to `api` (APIs & automation), next to Pipedream and Beeceptor.

An inbound webhook relay: you point a provider's webhook URL at it instead of your own server, and it stores each event, retries delivery when your endpoint is down, and keeps the request body so you can look at it or replay it later.

## Against the editorial criteria

- **Ongoing free tier, not a trial** — 3,000 events/month capped at 100/day, 1 app, 3 delivery attempts, 3 days of history. No expiry.
- **Relevant to developers and small teams** — receiving a webhook otherwise means running a public endpoint that answers at any hour, even when the handler is twenty lines.
- **Official docs for the free allowance** — https://anyhook.net/pricing lists every limit per plan.
- **Direct pricing URL** — added to `pricingUrls` as https://anyhook.net/pricing.
- **No misleading claims** — the entry states the daily cap alongside the monthly one, because the daily cap is the one that bites first.

Access requirement: sign-up, no credit card. I left it out of `accessRequirements` to match Beeceptor and Pipedream, and said "with no credit card" in the free-tier line instead.

## Files touched

- `src/data/resources.ts` — `pricingUrls` entry and the catalog entry (en + es)
- `src/data/free-tiers.ts` — free allowance (en + es)

## Checks

- [x] `pnpm check` — 25 files, 0 errors, 0 warnings, 0 hints
- [x] `pnpm build` — 258 pages, complete
- [x] `/tools/anyhook` and `/es/tools/anyhook` both render

One thing I did not touch: `sourceReviewedAt` is a single catalog-wide constant, and changing it would claim the whole catalog was re-reviewed rather than just this entry. I verified AnyHook's limits against the live pricing page on 2026-08-26. Happy to bump it if you would rather it move on every change.

## Disclosure

I maintain AnyHook. Decline it if it does not clear the bar; the free tier is real and the limits above are what the pricing page says.
